### PR TITLE
Improve batch extractor error handling

### DIFF
--- a/src/laurium/decoder_models/extract.py
+++ b/src/laurium/decoder_models/extract.py
@@ -3,6 +3,7 @@
 import logging
 
 import pandas as pd
+from httpx import ConnectError
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.output_parsers import PydanticOutputParser
@@ -134,6 +135,10 @@ class BatchExtractor:
         except OutputParserException as e:
             self.logger.error(f"Batch processing failed completely: {str(e)}")
             processed_results = [failure_result] * len(texts)
+        except ConnectError as e:
+            raise RuntimeError(
+                "Could not connect to Ollama - have you run `ollama serve`?"
+            ) from e
 
         # Individual processing for failed items
         for i, text in enumerate(texts):


### PR DESCRIPTION
The current implementation of the `BatchExtractor` class catches all exceptions with the cryptic error message "Batch processing failed completely", which led to error messages around connection/Bedrock configuration issues being suppressed. I've narrowed the scope of errors caught, and added custom messaging for an Ollama-related connection issue.

Closes #18.

The acceptance criteria on the issue are listed as

- Implement connection test for Ollama and AWS Bedrock
- Add proper error handling and user feedback for connection failures
- Provide troubleshooting guidance for common connection issues

however, after discussion we decided that it was more appropriate to narrow the scope of the exception being caught instead of providing a full-blown connection test for Ollama/AWS/any future backends. The AWS errors are normally pretty clear on what's gone wrong, so I think we don't need any additional messaging around those; I've added a message clarifying the "Connection refused" error that is raised if Ollama is not accessible. 

The reviewer should focus on
- Testing the proposed changes (e.g. using the example scripts in the README, with changes made to ensure errors are raised)
- Verifying that the code meets team standards
- Checking whether the proposed fix covers the issue satisfactorily.