### PR TITLE
Let Ruff determine python version

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,3 @@
-target-version = "py312"
 line-length = 79
 
 [lint]


### PR DESCRIPTION
Following the guidance [here](https://docs.astral.sh/ruff/configuration/#inferring-the-python-version), instead of specifying a fixed python version we can leave it unspecified, in which case ruff will pull it directly from the pyproject.toml.

To review, check that the reasoning above tallies with the guidance, and that the ruff CI check passes.

Closes #7.