### PR TITLE
Implement max_retries parameter

### DIFF
--- a/src/laurium/decoder_models/extract.py
+++ b/src/laurium/decoder_models/extract.py
@@ -37,7 +37,7 @@ class BatchExtractor:
     max_concurrency : int
         Maximum number of concurrent operations allowed.
     max_retries : int
-        Maximum number of retry attempts for failed individual processing.
+        Maximum number of retries for fallback individual processing.
     prompt : ChatPromptTemplate
         The configured prompt template.
     logger : logging.Logger


### PR DESCRIPTION
Description

This PR removes the non-functional max_retries parameter from the BatchExtractor class.
The changes in this PR are needed because the max_retries parameter was defined in the class constructor and documentation but was never actually used in the retry logic, making it misleading to users who expected it to control
retry behaviour.

Related Issue
Closes #24 

Type of Change
- [x]  Bug fix
- [ ]   New feature
- [ ]   Documentation update
- [ ]   Performance improvement
- [ ]   Code refactoring
- [ ]   Other (please describe):

:white_check_mark: Author's Pre-Review Checklist
- [x]   Code executes without errors (including notebooks and how-to guides)
- [ ]   Virtual environment can be created and dependencies install correctly
- [x]   All tests pass locally
- [x]   Documentation is up-to-date
- [x]   Code follows team standards (typing, docstrings, formatting)
- [x]   Branch is up-to-date with target branch
- [ ]   I have added tests that prove my fix is effective or that my feature works

:mag: What should the reviewer concentrate on?
- Quick check to verify the parameter has been completely removed from all docstrings, method signatures, and class attributes
- Confirm that the BatchExtractor still functions correctly without the unused parameter
- Review that the class documentation accurately reflects the current functionality

:technologist: How should the reviewer test these changes?
- Instantiate a BatchExtractor without the max_retries parameter and verify it works as expected

:package: New packages
- No additional packages are needed to run the code in this PR.

:new: Updates to documentation
- The class docstring and method docstrings have been updated to remove references to the max_retries parameter