### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laurium"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   { name="Tom O'Connor", email="tom.oconnor@justice.gov.uk" },
   { name="William Martin", email="william.martin1@justice.gov.uk" },


### PR DESCRIPTION
As pointed out by @tpoconnor-14, need to complete a new release as the docs have gone out-of-sync. (Maybe in the future we only update the docs on a package release?)