### PR TITLE
Update GitHub config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,7 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Run SLSA check
-        uses: ministryofjustice/devsecops-actions/sca/slsa@e3c63a5986ea6e7d57d38b7f72e5b8cf08dc7020 # latest
+        uses: ministryofjustice/devsecops-actions/sca/slsa@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
 
       - name: Install requirements
         run: uv sync --group docs

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run SLSA check
-        uses: ministryofjustice/devsecops-actions/sca/slsa@e3c63a5986ea6e7d57d38b7f72e5b8cf08dc7020 # latest
+        uses: ministryofjustice/devsecops-actions/sca/slsa@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
 
       - name: Build environment
         run: |


### PR DESCRIPTION
This introduces two changes:
- Fix the SLSA check to use the last minor release (v1.5.0 in this case), instead of pinning it to the latest version
- Squash Dependabot pre-commit updates into a single PR