### PR TITLE
pin pytorch to 2.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ encoder = [
     "datasets>=3.6.0",
     "optuna>=4.5.0",
     "peft>=0.15.2",
-    "pytorch-lightning>=2.5.2",
+    "pytorch-lightning==2.6.1",
     "torch>=2.4.0",
     "transformers>=4.44.2,<5",
     "setfit>=1.1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-18T12:36:17.171062917Z"
+exclude-newer = "2026-04-28T06:38:17.504035402Z"
 exclude-newer-span = "PT72H"
 
 [[package]]
@@ -1556,7 +1556,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=5.28.1" },
     { name = "pydantic", specifier = ">=2.6.3" },
     { name = "pydbtools", specifier = ">=5.8.1" },
-    { name = "pytorch-lightning", marker = "extra == 'encoder'", specifier = ">=2.5.2" },
+    { name = "pytorch-lightning", marker = "extra == 'encoder'", specifier = "==2.6.1" },
     { name = "setfit", marker = "extra == 'encoder'", specifier = ">=1.1.3" },
     { name = "spacy", specifier = "==3.8.13,<3.9" },
     { name = "torch", marker = "extra == 'encoder'", specifier = ">=2.4.0" },


### PR DESCRIPTION
There's been a security incident involving [pytorch](https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3) and the recommendation is to pin to version 2.6.1 which has been done in this PR

Just need a quick check to see if the version is pinned correctly and that all the tests run please

To sync all files please run this:
`uv sync --extra encoder --extra notebooks`

To run tests using encoder packages please run these:
`uv run --extra encoder  pytest tests/test_fine_tune.py `
`uv run --extra encoder  pytest tests/test_model_nli.py `
`uv run --extra encoder  pytest tests/test_setfit.py`