### PR TITLE
update setfit functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Supported Bedrock models:
 | | `load` | Load and chunk data from various sources (CSV, SQL, etc.) |
 | **encoder_models** | `nli` | Natural Language Inference models for text analysis |
 | | `fine_tune` | Fine-tune transformer models for custom tasks |
+| | `setfit` | SetFit architecture for few-shot classification |
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,6 +189,31 @@ results = extractor.process_chunk(data, text_column="text")
 print(results.to_string(index=False))
 ```
 
+This will output something like:
+```
+                                    text  ai_label
+         I absolutely love this product!         1
+  This is terrible, worst purchase ever.         0
+Great value for money, highly recommend!         1
+```
+
+#### Using the AI Gateway (MoJ specific)
+
+The AI Gateway provides an OpenAI-compatible API, therefore we can set the
+platform to be `"openai"` with a custom base URL.
+
+```python
+# Same code as above, but for AI Gateway
+sentiment_llm = llm.create_llm(
+    llm_platform="openai",
+    model_name="bedrock-claude-haiku-4-5",
+    openai_api_base="https://llm-gateway.development.data-platform.service.justice.gov.uk/",
+    api_key=os.getenv("AI_GATEWAY_API_KEY")
+)
+# ... rest of the code remains the same
+```
+
+
 #### Using AWS Bedrock
 ```python
 # Same code as above, but create LLM with Bedrock:
@@ -201,12 +226,21 @@ sentiment_llm = llm.create_llm(
 # ... rest of the code remains the same
 ```
 
-This will output something like:
-```
-                                    text  ai_label
-         I absolutely love this product!         1
-  This is terrible, worst purchase ever.         0
-Great value for money, highly recommend!         1
+#### Other LLM providers
+
+Laurium is also compatible with any of the [chat models provided by langchain](
+https://docs.langchain.com/oss/python/integrations/chat). For example, to use
+with llama.cpp,
+
+```python
+from langchain_community.chat_models import ChatLlamaCpp
+
+# Same code as above, but create LLM with LangChain:
+sentiment_llm = ChatLlamaCpp(
+    temperature=0.0,
+    model_path="path/to/a/local/model.gguf",
+)
+# ... rest of the code remains the same
 ```
 
 ### Multi-Field Extraction
@@ -400,6 +434,7 @@ Supported Bedrock models:
 | | `load` | Load and chunk data from various sources (CSV, SQL, etc.) |
 | **encoder_models** | `nli` | Natural Language Inference models for text analysis |
 | | `fine_tune` | Fine-tune transformer models for custom tasks |
+| | `setfit` | SetFit architecture for few-shot classification |
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laurium"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   { name="Tom O'Connor", email="tom.oconnor@justice.gov.uk" },
   { name="William Martin", email="william.martin1@justice.gov.uk" },

--- a/src/laurium/encoder_models/setfit/setfit.py
+++ b/src/laurium/encoder_models/setfit/setfit.py
@@ -39,7 +39,8 @@ class SetFit:
         Parameters
         ----------
         model_init : dict[str, Any]
-            Arguments for model initialization passed to SetFitModel.
+            Arguments for model initialization including model name/path passed
+            to SetFitModel.
         training_args : dict[str, Any]
             Training arguments passed to TrainingArguments constructor to
             configure the training process.
@@ -64,7 +65,7 @@ class SetFit:
         This abstraction is needed as a fresh instance of a model is needed
         for hyperparameter tuning.
 
-        `params` is passed by hp search, can be ignored if not used.
+        `params` is passed by hyperparameter search, can be ignored if not used.
 
         Returns
         -------
@@ -76,7 +77,7 @@ class SetFit:
     def create_setfit_trainer(
         self,
         train_dataset: Dataset,
-        eval_dataset: Dataset,
+        eval_dataset: Dataset | None = None,
         model_init_fn: Callable[[], SetFitModel] | None = None,
     ) -> Trainer:
         """Create trainer for setfit.
@@ -85,7 +86,7 @@ class SetFit:
         ----------
         train_dataset: Dataset
             training dataset used for training.
-        eval_dataset: Dataset
+        eval_dataset: Dataset | None = None
             validation dataset for training
         model_init_fn : Callable, optional
             Model initialization function for hyperparameter search.
@@ -122,7 +123,16 @@ class SetFit:
             dataframe containing eval data
         """
         train_dataset = Dataset.from_pandas(train_df)
-        eval_dataset = Dataset.from_pandas(eval_df)
+        if eval_df is None:
+            if self.training_args.eval_strategy.lower() != "no":
+                # Must provide an eval dataset if eval strategy specified
+                raise ValueError(
+                    "eval_strategy='no' in training_args if eval_df provided"
+                )
+            eval_dataset = None
+        else:
+            eval_dataset = Dataset.from_pandas(eval_df)
+
         trainer = self.create_setfit_trainer(train_dataset, eval_dataset)
         trainer.train()
         return trainer

--- a/tests/test_setfit.py
+++ b/tests/test_setfit.py
@@ -7,13 +7,6 @@ from datasets import Dataset
 from laurium.components.setfit_eval_metrics import compute_metrics
 from laurium.encoder_models.setfit.setfit import SetFit
 
-blah = pd.DataFrame(
-    {
-        "text_col": ["This is a Positive text", "This is a Negative text"],
-        "label_col": [1, 0],
-    }
-)
-
 
 @pytest.fixture
 def train_eval_data():
@@ -60,6 +53,38 @@ def set_fit_trainer(train_eval_data):
     )
 
 
+@pytest.fixture
+def set_fit_trainer_no_eval(train_eval_data):
+    """Initialise setfit trainer without eval."""
+    setfit_model_init = {
+        "pretrained_model_name_or_path": "sentence-transformers/all-MiniLM-L6-v2",
+        "use_differentiable_head": False,
+    }
+
+    # Training arguments for parameter tuning
+    setfit_training_args = {
+        "sampling_strategy": "oversampling",
+        "max_steps": -1,
+        "end_to_end": False,
+        "head_learning_rate": 1e-2,
+        "body_learning_rate": [2e-5, 1e-5],
+        "num_epochs": [1, 16],
+        "load_best_model_at_end": False,
+        "eval_strategy": "no",
+    }
+
+    # Initialize fine-tuner
+    return SetFit(
+        metric=compute_metrics,
+        model_init=setfit_model_init,
+        training_args=setfit_training_args,
+        mapping={
+            train_eval_data.columns[0]: "text",
+            train_eval_data.columns[1]: "label",
+        },
+    )
+
+
 def test_create_trainer_for_search(set_fit_trainer, train_eval_data):
     """Tests the create_trainer_for_search function creates trainer correctly.
 
@@ -92,3 +117,20 @@ def test_create_setfit_regular(set_fit_trainer, train_eval_data):
     )
     assert trainer.model is not None
     assert trainer.model_init is None
+
+
+def test_setfit_no_eval(set_fit_trainer_no_eval, train_eval_data):
+    """Tests the regular create_setfit_trainer function works without eval dataset.
+
+    Parameters
+    ----------
+    set_fit_trainer_no_eval: SetFit
+        Initialisation of SetFit class without eval dataset.
+    """
+    train_eval_dataset = Dataset.from_pandas(train_eval_data)
+
+    trainer = set_fit_trainer_no_eval.create_setfit_trainer(train_eval_dataset)
+    assert trainer.model is not None
+    assert trainer.model_init is None
+    assert trainer.train_dataset is not None
+    assert trainer.eval_dataset is None

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-28T06:38:17.504035402Z"
+exclude-newer = "2026-04-28T15:43:17.407809568Z"
 exclude-newer-span = "PT72H"
 
 [[package]]
@@ -1481,7 +1481,7 @@ wheels = [
 
 [[package]]
 name = "laurium"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Updates setfit script to add logic that allows instances where eval_df isn't required by setfit trainer

I've also updated the test.

Run the following to check this test runs without error: `uv run --extra encoder pytest tests/test_setfit.py `


