### PR TITLE
Automerge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One of the main forms of maintenance at the moment is merging dependabot PRs. Reviews for these PRs are straightforward (and mainly consist of verifying that the code passes tests). This PR proposes foregoing reviews for dependabot PRs and allowing them to automatically merge. 

Dependabot is already configured with a cool-down period, which should be enough to head off supply-chain attacks, while the automated response should improve our security posture vs waiting a week or two for one of us to manually review it. The dependabot PRs will still have to pass all tests before merging, so can't be merged if anything fails.

