### PR TITLE
Add `Labeller` class

### DIFF
--- a/src/laurium/decoder_models/extractor.py
+++ b/src/laurium/decoder_models/extractor.py
@@ -10,6 +10,28 @@ from laurium.decoder_models import prompts, pydantic_models
 
 
 class Extractor:
+    """
+    AI extractor for extracting structured information from text.
+
+    Parameters
+    ----------
+    schema : dict[str, tuple[Any, str]]
+        A dictionary defining the desired output from the model, where
+        each key is a field name, and the value is a tuple containing
+        the field type and its description.
+    llm : dict[str, Any] | BaseChatModel
+        Either a dictionary of parameters to create an LLM instance or
+        a pre-configured language model instance (see
+        `laurium.decoder_models.llm.create_llm`).
+    prompt : str, optional
+        The base prompt to use for the extraction task.
+        Default is "You are an expert annotator. Annotate the following
+        text."
+    **prompt_kwargs : dict[str, Any]
+        Additional arguments to customize the prompt creation, such as
+        keywords for the system message.
+    """
+
     def __init__(
         self,
         schema: dict[str, tuple[Any, str]],
@@ -57,6 +79,26 @@ class Extractor:
     def _create_prompt(
         self, prompt: str, **prompt_kwargs: dict[str, Any]
     ) -> str:
+        """
+        Build the prompt for the labelling task.
+
+        This takes the base prompt, along with any additional arguments
+        (such as keywords), and puts together a complete prompt to
+        provide context to the language model for the labelling task.
+
+        Parameters
+        ----------
+        prompt : str
+            The base prompt to use for the labelling task.
+        **prompt_kwargs : dict[str, Any]
+            Additional arguments to customize the prompt creation, such
+            as keywords for the system message.
+
+        Returns
+        -------
+        str
+            The fully constructed prompt.
+        """
         system_message = prompts.create_system_message(
             base_message=prompt,
             keywords=prompt_kwargs.pop("keywords"),
@@ -71,6 +113,19 @@ class Extractor:
         )
 
     def label(self, text: str) -> dict:
+        """
+        Label a single piece of text.
+
+        Parameters
+        ----------
+        text : str
+            The text to be labelled.
+
+        Returns
+        -------
+        dict
+            The output label as a dictionary.
+        """
         return self.chain.invoke(text)
 
     def batch_label(
@@ -79,6 +134,25 @@ class Extractor:
         text_column: str,
         max_concurrency: int = 8,
     ) -> pd.DataFrame:
+        """
+        Batch label a column of text in a pandas DataFrame.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The DataFrame containing the texts to be labelled.
+        text_column : str
+            The name of the column to be labelled.
+        max_concurrency : int, optional
+            The maximum number of concurrent requests to the language
+            model (default is 8).
+
+        Returns
+        -------
+        pd.DataFrame
+            The original DataFrame with additional columns corresponding
+            to the labelled outputs for each record.
+        """
         texts = df[text_column].tolist()
 
         batch_results = self.chain.batch(

--- a/src/laurium/decoder_models/extractor.py
+++ b/src/laurium/decoder_models/extractor.py
@@ -107,11 +107,18 @@ class Extractor:
         """
         system_message = prompts.create_system_message(
             base_message=prompt,
-            keywords=prompt_kwargs.pop("keywords"),
+            keywords=prompt_kwargs.pop("keywords", None),
         )
 
         return prompts.create_prompt(
             system_message=system_message,
+            examples=prompt_kwargs.pop("examples", []),
+            example_human_template=prompt_kwargs.pop(
+                "example_human_template", ""
+            ),
+            example_assistant_template=prompt_kwargs.pop(
+                "example_assistant_template", ""
+            ),
             final_query="Analyze this text: {text}",
             schema=self.schema_dtypes,
             descriptions=self.schema_desc,

--- a/src/laurium/decoder_models/extractor.py
+++ b/src/laurium/decoder_models/extractor.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pandas as pd
+from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.output_parsers import PydanticOutputParser
 
@@ -76,6 +77,9 @@ class Extractor:
             {"text": lambda x: x} | self.prompt | self.llm | self.parser | dict
         )
 
+        # Create null result template (for failed extractions)
+        self.failed_result_template = {key: None for key in self.schema_dtypes}
+
     def _create_prompt(
         self, prompt: str, **prompt_kwargs: dict[str, Any]
     ) -> str:
@@ -133,6 +137,8 @@ class Extractor:
         df: pd.DataFrame,
         text_column: str,
         max_concurrency: int = 8,
+        max_retries: int = 3,
+        ignore_errors: bool = False,
     ) -> pd.DataFrame:
         """
         Batch label a column of text in a pandas DataFrame.
@@ -145,7 +151,13 @@ class Extractor:
             The name of the column to be labelled.
         max_concurrency : int, optional
             The maximum number of concurrent requests to the language
-            model (default is 8).
+            model. Default is 8.
+        max_retries : int, optional
+            The maximum number of retries for failed requests.
+            Default is 3.
+        ignore_errors : bool, optional
+            Whether to ignore errors (other than parsing errors) during
+            batch processing. Default is False.
 
         Returns
         -------
@@ -158,7 +170,46 @@ class Extractor:
         batch_results = self.chain.batch(
             texts,
             {"max_concurrency": max_concurrency},
+            return_exceptions=True,
         )
+
+        # Retry failed requests up to max_retries times
+        for _ in range(max_retries):
+            # Pull out indices of failed results
+            failed_indices = []
+            for idx, result in enumerate(batch_results):
+                if isinstance(result, dict):
+                    # Success
+                    continue
+                if isinstance(result, OutputParserException):
+                    # Ill-formatted output, select for retry
+                    failed_indices.append(idx)
+                    continue
+
+                # If we're here, we received some other type of error
+                if not ignore_errors:
+                    raise result
+                failed_indices.append(idx)  # If ignoring errors, retry index
+
+            if not failed_indices:
+                # No failed results, exit the retry loop
+                break
+
+            # Retry failed requests
+            retry_texts = [texts[idx] for idx in failed_indices]
+            retry_results = self.chain.batch(
+                retry_texts,
+                {"max_concurrency": max_concurrency},
+                return_exceptions=True,
+            )
+
+            for idx, result in zip(failed_indices, retry_results, strict=True):
+                batch_results[idx] = result
+
+        # Exhausted retries, fill in any remaining failures with null result
+        for idx, result in enumerate(batch_results):
+            if not isinstance(result, dict):
+                batch_results[idx] = self.failed_result_template.copy()
 
         results_df = pd.DataFrame(batch_results)
         return pd.concat([df.reset_index(drop=True), results_df], axis=1)

--- a/src/laurium/decoder_models/extractor.py
+++ b/src/laurium/decoder_models/extractor.py
@@ -1,0 +1,90 @@
+"""Labeller class for annotating text using an LLM."""
+
+from typing import Any
+
+import pandas as pd
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.output_parsers import PydanticOutputParser
+
+from laurium.decoder_models import prompts, pydantic_models
+
+
+class Extractor:
+    def __init__(
+        self,
+        schema: dict[str, tuple[Any, str]],
+        llm: dict[str, Any] | BaseChatModel,
+        prompt: str = (
+            "You are an expert annotator. Extract information from the text "
+            "following the schema provided below."
+        ),
+        **prompt_kwargs: dict[str, Any],
+    ):
+        # Set up schema and Pydantic model
+        self.schema_dtypes = {
+            key: field_type for key, (field_type, _) in schema.items()
+        }
+        self.schema_desc = {key: desc for key, (_, desc) in schema.items()}
+        self.pydantic_model = pydantic_models.make_dynamic_example_model(
+            schema=self.schema_dtypes,
+            descriptions=self.schema_desc,
+            model_name="DynamicExampleModel",
+        )
+
+        # Set up LLM
+        if isinstance(llm, dict):
+            from laurium.decoder_models.llm import create_llm
+
+            self.llm = create_llm(**llm)
+        elif isinstance(llm, BaseChatModel):
+            self.llm = llm
+        else:
+            raise ValueError(
+                "llm must be either a dict or an instance of BaseChatModel"
+            )
+
+        # Set up prompt
+        self.prompt = self._create_prompt(prompt, **prompt_kwargs)
+
+        # Create parser
+        self.parser = PydanticOutputParser(pydantic_object=self.pydantic_model)
+
+        # Create chain
+        self.chain = (
+            {"text": lambda x: x} | self.prompt | self.llm | self.parser | dict
+        )
+
+    def _create_prompt(
+        self, prompt: str, **prompt_kwargs: dict[str, Any]
+    ) -> str:
+        system_message = prompts.create_system_message(
+            base_message=prompt,
+            keywords=prompt_kwargs.pop("keywords"),
+        )
+
+        return prompts.create_prompt(
+            system_message=system_message,
+            final_query="Analyze this text: {text}",
+            schema=self.schema_dtypes,
+            descriptions=self.schema_desc,
+            **prompt_kwargs,
+        )
+
+    def label(self, text: str) -> dict:
+        return self.chain.invoke(text)
+
+    def batch_label(
+        self,
+        df: pd.DataFrame,
+        text_column: str,
+        max_concurrency: int = 8,
+    ) -> pd.DataFrame:
+        texts = df[text_column].tolist()
+
+        batch_results = self.chain.batch(
+            texts,
+            {"max_concurrency": max_concurrency},
+        )
+
+        results_df = pd.DataFrame(batch_results)
+        return pd.concat([df.reset_index(drop=True), results_df], axis=1)

--- a/src/laurium/decoder_models/extractor.py
+++ b/src/laurium/decoder_models/extractor.py
@@ -78,7 +78,9 @@ class Extractor:
         )
 
         # Create null result template (for failed extractions)
-        self.failed_result_template = {key: None for key in self.schema_dtypes}
+        self.failed_result_template = {
+            key: pd.NA for key in self.schema_dtypes
+        }
 
     def _create_prompt(
         self, prompt: str, **prompt_kwargs: dict[str, Any]
@@ -211,5 +213,7 @@ class Extractor:
             if not isinstance(result, dict):
                 batch_results[idx] = self.failed_result_template.copy()
 
-        results_df = pd.DataFrame(batch_results)
+        results_df = pd.DataFrame(
+            batch_results, columns=self.schema_dtypes
+        ).convert_dtypes()
         return pd.concat([df.reset_index(drop=True), results_df], axis=1)

--- a/src/laurium/decoder_models/labeller.py
+++ b/src/laurium/decoder_models/labeller.py
@@ -1,0 +1,77 @@
+"""Labeller class for annotating text using an LLM."""
+
+from typing import Any, Literal
+
+import jinja2
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from laurium.decoder_models.extractor import Extractor
+
+
+class Labeller(Extractor):
+    """
+    AI labeller for annotating text using an LLM.
+
+    Parameters
+    ----------
+    labels : dict[str, str]
+        A dictionary defining the desired output from the model, where
+        each key is a field name, and the value is a description of the
+        label.
+    llm : dict[str, Any] | BaseChatModel
+        Either a dictionary of parameters to create an LLM instance or
+        a pre-configured language model instance (see
+        `laurium.decoder_models.llm.create_llm`).
+    prompt : str, optional
+        The base prompt to use for the extraction task.
+        Default is "You are an expert annotator. Label the following
+        text using the provided labels."
+    **prompt_kwargs : dict[str, Any]
+        Additional arguments to customize the prompt creation, such as
+        keywords for the system message.
+    """
+
+    def __init__(
+        self,
+        labels: dict[str, str],
+        llm: dict[str, Any] | BaseChatModel,
+        prompt: str = (
+            "You are an expert annotator. Label the following text using the "
+            "provided labels."
+        ),
+        acronyms: dict[str, str] | None = None,
+        **prompt_kwargs: dict[str, Any],
+    ):
+        # Set up schema and Pydantic model
+        self.labels = labels
+
+        schema = {
+            "label": (
+                Literal[tuple(labels)],  # type: ignore
+                (
+                    f"The label assigned to the free text; one of "
+                    f"{list(labels)}."
+                ),
+            ),
+            "explanation": (
+                str,
+                "The explanation for why this label was chosen.",
+            ),
+        }
+
+        # Build label prompt from template
+        env = jinja2.Environment(loader=jinja2.PackageLoader(__name__))
+        template = env.get_template("label_prompt_template.jinja")
+        system_prompt = template.render(
+            base_prompt=prompt,
+            labels=labels,
+            acronyms=acronyms,
+        )
+
+        # Call extractor constructor
+        super().__init__(
+            schema=schema,
+            llm=llm,
+            prompt=system_prompt,
+            **prompt_kwargs,
+        )

--- a/src/laurium/decoder_models/templates/__init__.py
+++ b/src/laurium/decoder_models/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Jinja prompt templates for data extraction."""

--- a/src/laurium/decoder_models/templates/label_prompt_template.jinja
+++ b/src/laurium/decoder_models/templates/label_prompt_template.jinja
@@ -1,0 +1,26 @@
+{{ base_prompt }}
+
+{% if acronyms %}
+You may find the following acronyms helpful:
+{%- for acronym, description in acronyms.items() %}
+    {{ acronym }} - {{ description }}
+{%- endfor %}
+Do not guess unknown acronyms.
+
+{% endif -%}
+
+# Labels
+
+Classify each case note with the following labels:
+{% for label, description in labels.items() %}
+  "{{ label }}" - {{ description }}
+{% endfor %}
+
+# Output format
+
+Return output structured as a JSON with two fields:
+    label: str - one of the labels (
+        {%- for label in labels -%}"{{label}}"{% if not loop.last %}, {% endif %}{% endfor -%}
+    )
+    explanation: str - a string explaining your reasoning.
+Do not enclose your JSON output in backticks.

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,250 @@
+"""Unit tests for the Extractor class."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from langchain_core.exceptions import OutputParserException
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from pytest_mock.plugin import MockerFixture
+
+from laurium.decoder_models.extractor import Extractor
+
+SCHEMA = {"label": (str, "classification label")}
+
+
+def _make_extractor(mocker: MockerFixture) -> Extractor:
+    """Create an Extractor with only its batch dependencies configured."""
+    mocker.patch.object(Extractor, "__init__", return_value=None)
+    extractor = Extractor.__new__(Extractor)
+    extractor.chain = MagicMock()
+    extractor.schema_dtypes = {"label": str}
+    extractor.failed_result_template = {"label": pd.NA}
+    return extractor
+
+
+def test_init_accepts_chat_model_and_builds_schema() -> None:
+    """The constructor stores the model and builds the requested schema."""
+    llm = FakeListChatModel(responses=['{"label": "positive"}'])
+
+    extractor = Extractor(SCHEMA, llm, keywords=["refund"])
+
+    assert extractor.llm is llm
+    assert extractor.schema_dtypes == {"label": str}
+    assert extractor.schema_desc == {"label": "classification label"}
+    assert extractor.pydantic_model.model_fields["label"].description == (
+        "classification label"
+    )
+    assert extractor.failed_result_template == {"label": pd.NA}
+
+
+def test_init_creates_llm_from_configuration(mocker: MockerFixture) -> None:
+    """Dictionary configuration is passed to the LLM factory."""
+    llm = FakeListChatModel(responses=['{"label": "positive"}'])
+    create_llm = mocker.patch(
+        "laurium.decoder_models.llm.create_llm", return_value=llm
+    )
+
+    extractor = Extractor(
+        SCHEMA,
+        {"llm_platform": "ollama", "model_name": "test-model"},
+        keywords=[],
+    )
+
+    assert extractor.llm is llm
+    create_llm.assert_called_once_with(
+        llm_platform="ollama", model_name="test-model"
+    )
+
+
+def test_prompt_contains_keywords_and_schema() -> None:
+    """The generated prompt includes keyword and schema guidance."""
+    extractor = Extractor(
+        SCHEMA,
+        FakeListChatModel(responses=['{"label": "positive"}']),
+        keywords=["refund"],
+    )
+
+    prompt_text = extractor.prompt.format(text="Customer received a refund")
+
+    assert "Pay special attention to these keywords: refund" in prompt_text
+    assert "label: classification label" in prompt_text
+    assert "Analyze this text: Customer received a refund" in prompt_text
+
+
+def test_init_rejects_unsupported_llm() -> None:
+    """Unsupported LLM values fail with a useful error."""
+    with pytest.raises(ValueError, match="llm must be either a dict"):
+        Extractor(SCHEMA, object(), keywords=[])
+
+
+def test_init_accepts_prompt_without_keywords() -> None:
+    """The optional prompt customization does not require keywords."""
+    extractor = Extractor(
+        SCHEMA,
+        FakeListChatModel(responses=['{"label": "positive"}']),
+    )
+
+    assert extractor.prompt is not None
+
+
+def test_label_delegates_to_chain(mocker: MockerFixture) -> None:
+    """Label forwards one text and returns the chain result."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.invoke.return_value = {"label": "positive"}
+
+    result = extractor.label("The issue was resolved.")
+
+    assert result == {"label": "positive"}
+    extractor.chain.invoke.assert_called_once_with("The issue was resolved.")
+
+
+def test_label_propagates_parser_errors(mocker: MockerFixture) -> None:
+    """Parser errors from a single extraction are not swallowed."""
+    extractor = _make_extractor(mocker)
+    error = OutputParserException("invalid output")
+    extractor.chain.invoke.side_effect = error
+
+    with pytest.raises(OutputParserException) as raised:
+        extractor.label("Unparseable response")
+
+    assert raised.value is error
+
+
+def test_batch_label_appends_results_and_forwards_concurrency(
+    mocker: MockerFixture,
+) -> None:
+    """Successful batch output is aligned with the input rows."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.batch.return_value = [
+        {"label": "positive"},
+        {"label": "negative"},
+    ]
+    frame = pd.DataFrame(
+        {"text": ["Good service", "Poor service"], "case_id": [4, 9]},
+        index=[10, 20],
+    )
+
+    result = extractor.batch_label(frame, "text", max_concurrency=2)
+
+    assert result.to_dict("records") == [
+        {"text": "Good service", "case_id": 4, "label": "positive"},
+        {"text": "Poor service", "case_id": 9, "label": "negative"},
+    ]
+    assert result.index.tolist() == [0, 1]
+    extractor.chain.batch.assert_called_once_with(
+        ["Good service", "Poor service"],
+        {"max_concurrency": 2},
+        return_exceptions=True,
+    )
+
+
+def test_batch_label_retries_parser_failure_and_preserves_success(
+    mocker: MockerFixture,
+) -> None:
+    """Only failed positions are retried and later results replace them."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.batch.side_effect = [
+        [{"label": "positive"}, OutputParserException("invalid output")],
+        [{"label": "negative"}],
+    ]
+    frame = pd.DataFrame({"text": ["Good", "Bad"]})
+
+    result = extractor.batch_label(frame, "text", max_concurrency=3)
+
+    assert result["label"].tolist() == ["positive", "negative"]
+    assert extractor.chain.batch.call_args_list[1].args[0] == ["Bad"]
+
+
+def test_batch_label_raises_non_parser_error_when_not_ignoring(
+    mocker: MockerFixture,
+) -> None:
+    """Non-parser errors are raised when ignore_errors is false."""
+    extractor = _make_extractor(mocker)
+    error = RuntimeError("service unavailable")
+    extractor.chain.batch.return_value = [error]
+
+    with pytest.raises(RuntimeError) as raised:
+        extractor.batch_label(pd.DataFrame({"text": ["Hello"]}), "text")
+
+    assert raised.value is error
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param(
+            OutputParserException("invalid output"),
+            id="parser-error",
+        ),
+        pytest.param(RuntimeError("service unavailable"), id="runtime-error"),
+    ],
+)
+def test_batch_label_fills_exhausted_errors_when_ignoring(
+    mocker: MockerFixture, failure: Exception
+) -> None:
+    """Ignored failures are retried, then replaced with null fields."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.batch.side_effect = [
+        [failure],
+        [failure],
+    ]
+
+    result = extractor.batch_label(
+        pd.DataFrame({"text": ["Hello"]}),
+        "text",
+        max_retries=1,
+        ignore_errors=True,
+    )
+
+    assert pd.isna(result.loc[0, "label"])
+    assert extractor.chain.batch.call_count == 2
+
+
+def test_batch_label_preserves_nullable_integer_dtype_for_null_result(
+    mocker: MockerFixture,
+) -> None:
+    """An integer result column remains nullable when one extraction fails."""
+    extractor = _make_extractor(mocker)
+    extractor.schema_dtypes = {"count": int}
+    extractor.failed_result_template = {"count": pd.NA}
+    extractor.chain.batch.return_value = [
+        {"count": 3},
+        RuntimeError("service unavailable"),
+    ]
+    frame = pd.DataFrame({"text": ["Three items", "Unknown"]})
+
+    result = extractor.batch_label(
+        frame, "text", max_retries=0, ignore_errors=True
+    )
+
+    assert result["count"].dtype == pd.Int64Dtype()
+    assert result["count"].tolist() == [3, pd.NA]
+
+
+def test_batch_label_zero_retries_fills_initial_failure(
+    mocker: MockerFixture,
+) -> None:
+    """Zero retries means only the initial batch attempt is made."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.batch.return_value = [
+        OutputParserException("invalid output")
+    ]
+
+    result = extractor.batch_label(
+        pd.DataFrame({"text": ["Hello"]}), "text", max_retries=0
+    )
+
+    assert pd.isna(result.loc[0, "label"])
+    extractor.chain.batch.assert_called_once()
+
+
+def test_batch_label_empty_dataframe(mocker: MockerFixture) -> None:
+    """An empty input returns an empty frame with the result column."""
+    extractor = _make_extractor(mocker)
+    extractor.chain.batch.return_value = []
+
+    result = extractor.batch_label(pd.DataFrame({"text": []}), "text")
+
+    assert result.empty
+    assert list(result.columns) == ["text", "label"]

--- a/tests/test_labeller.py
+++ b/tests/test_labeller.py
@@ -1,0 +1,69 @@
+"""Unit tests for the Labeller class."""
+
+from typing import Literal
+
+import pytest
+from langchain_core.exceptions import OutputParserException
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+from laurium.decoder_models.labeller import Labeller
+
+LABELS = {"low": "Low priority", "high": "High priority"}
+
+
+def _make_labeller(response: str) -> Labeller:
+    """Build a Labeller with a deterministic mocked chat response."""
+    return Labeller(
+        LABELS,
+        FakeListChatModel(responses=[response]),
+        acronyms={"SLA": "service level agreement"},
+    )
+
+
+def test_prompt_contains_labels_descriptions_and_acronyms() -> None:
+    """The rendered prompt contains label and acronym guidance."""
+    labeller = _make_labeller('{"label": "low", "explanation": "urgent"}')
+
+    prompt_text = labeller.prompt.format(text="The request is urgent")
+
+    assert 'low" - Low priority' in prompt_text
+    assert 'high" - High priority' in prompt_text
+    assert "SLA - service level agreement" in prompt_text
+    assert 'label: str - one of the labels ("low", "high")' in prompt_text
+    assert "The request is urgent" in prompt_text
+
+
+@pytest.mark.parametrize("label", ["low", "high"])
+def test_label_accepts_each_provided_label(label: str) -> None:
+    """Every configured label is accepted by the output schema."""
+    labeller = _make_labeller(
+        f'{{"label": "{label}", "explanation": "valid"}}'
+    )
+
+    result = labeller.label("A case note")
+
+    assert result == {"label": label, "explanation": "valid"}
+    assert (
+        labeller.pydantic_model.model_fields["label"].annotation
+        is Literal["low", "high"]
+    )
+
+
+def test_label_rejects_label_outside_configured_labels() -> None:
+    """An output label absent from the configuration is rejected."""
+    labeller = _make_labeller('{"label": "medium", "explanation": "invalid"}')
+
+    with pytest.raises(OutputParserException):
+        labeller.label("A case note")
+
+
+def test_prompt_omits_acronym_section_when_acronyms_are_not_provided() -> None:
+    """No acronym guidance is rendered when no acronyms are supplied."""
+    labeller = Labeller(
+        LABELS,
+        FakeListChatModel(
+            responses=['{"label": "low", "explanation": "valid"}']
+        ),
+    )
+
+    assert "You may find the following acronyms helpful" not in labeller.prompt


### PR DESCRIPTION
Adds a simplified interface for labelling text with explanation.

Closes #199.

To test, you can run the included tests or try out a test script, e.g.
```python
import os
from laurium.decoder_models.labeller import Labeller

labeller = Labeller(
    labels={
        "positive": "The customer reports a satisfactory outcome.",
        "negative": "The customer reports an unsatisfactory outcome.",
        "neutral": "The note does not indicate a clear outcome.",
    },
    llm={
        "llm_platform": "openai",
        "model_name": "bedrock-claude-haiku-4-5",
        "openai_api_base": (
            "https://ai-gateway.justice.gov.uk/"
        ),
        "api_key": os.getenv("AI_GATEWAY_API_KEY"),
    },
    acronyms={"SLA": "service level agreement"},
)

result = labeller.label(
    "The replacement arrived within the SLA and resolved the issue."
)
print(result)
```

Not 100% happy with the tests yet so won't put up for review